### PR TITLE
Add HTTPD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ describe 'hello-world', ->
   beforeEach ->
     @room = helper.createRoom()
 
+  afterEach ->
+    @room.destroy()
+
   context 'user says hi to hubot', ->
     beforeEach ->
       @room.user.say 'alice', '@hubot hi'

--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ describe 'hello-world', ->
         ['hubot', '@bob hi']
       ]
 ```
+
+#### HTTPD
+
+By default Hubot enables a built in HTTP server. The server continues between
+tests and so requires it to be shutdown during teardown using `room.destroy()`.
+
+This feature can be turned off in tests that don't need it by passing using
+`helper.createRoom(http: false)`.
+
+See [the tests](test/httpd-world_test.coffee) for an example of testing the
+HTTP server.

--- a/README.md
+++ b/README.md
@@ -29,18 +29,17 @@ scriptHelper = new Helper('./scripts/specific-script.coffee')
 expect = require('chai').expect
 
 describe 'hello-world', ->
-  room = null
 
   beforeEach ->
-    room = helper.createRoom()
+    @room = helper.createRoom()
 
   context 'user says hi to hubot', ->
     beforeEach ->
-      room.user.say 'alice', '@hubot hi'
-      room.user.say 'bob',   '@hubot hi'
+      @room.user.say 'alice', '@hubot hi'
+      @room.user.say 'bob',   '@hubot hi'
 
     it 'should reply to user', ->
-      expect(room.messages).to.eql [
+      expect(@room.messages).to.eql [
         ['alice', '@hubot hi']
         ['hubot', '@alice hi']
         ['bob',   '@hubot hi']

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,8 +3,8 @@ Path  = require('path')
 Hubot = require('hubot')
 
 class MockRobot extends Hubot.Robot
-  constructor: ->
-    super null, null, false, 'hubot'
+  constructor: (httpd=false) ->
+    super null, null, httpd, 'hubot'
 
   loadAdapter: ->
     @adapter = new Room(@)
@@ -33,8 +33,8 @@ class Helper
   constructor: (scriptsPath) ->
     @scriptsPath = Path.resolve(Path.dirname(module.parent.filename), scriptsPath)
 
-  createRoom: ->
-    robot = new MockRobot
+  createRoom: (options={}) ->
+    robot = new MockRobot(options.httpd)
 
     if Fs.statSync(@scriptsPath).isDirectory()
       for file in Fs.readdirSync(@scriptsPath).sort()

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,7 +3,7 @@ Path  = require('path')
 Hubot = require('hubot')
 
 class MockRobot extends Hubot.Robot
-  constructor: (httpd=false) ->
+  constructor: (httpd=true) ->
     super null, null, httpd, 'hubot'
 
   loadAdapter: ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -23,6 +23,9 @@ class Room extends Hubot.Adapter
     user = new Hubot.User(userName)
     super new Hubot.TextMessage(user, message)
 
+  destroy: ->
+    @robot.server.close()
+
   reply: (envelope, strings...) ->
     @messages.push ['hubot', "@#{envelope.user.name} #{str}"] for str in strings
 

--- a/test/hello-world_test.coffee
+++ b/test/hello-world_test.coffee
@@ -6,7 +6,7 @@ expect = require('chai').expect
 describe 'hello-world', ->
 
   beforeEach ->
-    @room = helper.createRoom()
+    @room = helper.createRoom(httpd: false)
 
   context 'user says hi to hubot', ->
     beforeEach ->

--- a/test/hello-world_test.coffee
+++ b/test/hello-world_test.coffee
@@ -1,5 +1,5 @@
 Helper = require('../src/index')
-helper = new Helper('./scripts')
+helper = new Helper('./scripts/hello-world.coffee')
 
 expect = require('chai').expect
 

--- a/test/hello-world_test.coffee
+++ b/test/hello-world_test.coffee
@@ -4,18 +4,17 @@ helper = new Helper('./scripts/hello-world.coffee')
 expect = require('chai').expect
 
 describe 'hello-world', ->
-  room = null
 
   beforeEach ->
-    room = helper.createRoom()
+    @room = helper.createRoom()
 
   context 'user says hi to hubot', ->
     beforeEach ->
-      room.user.say 'alice', '@hubot hi'
-      room.user.say 'bob',   '@hubot hi'
+      @room.user.say 'alice', '@hubot hi'
+      @room.user.say 'bob',   '@hubot hi'
 
     it 'should reply to user', ->
-      expect(room.messages).to.eql [
+      expect(@room.messages).to.eql [
         ['alice', '@hubot hi']
         ['hubot', '@alice hi']
         ['bob',   '@hubot hi']

--- a/test/httpd-world_test.coffee
+++ b/test/httpd-world_test.coffee
@@ -1,5 +1,5 @@
 Helper = require('../src/index')
-helper = new Helper('./scripts/httpd-world.coffee')
+helper = new Helper('./scripts')
 http = require('http')
 
 expect = require('chai').expect
@@ -9,6 +9,9 @@ process.env.EXPRESS_PORT = 8080
 describe 'hello-world', ->
   beforeEach ->
     @room = helper.createRoom()
+
+  afterEach ->
+    @room.destroy()
 
   context 'GET /hello/world', ->
     beforeEach (done) ->

--- a/test/httpd-world_test.coffee
+++ b/test/httpd-world_test.coffee
@@ -1,0 +1,19 @@
+Helper = require('../src/index')
+helper = new Helper('./scripts/httpd-world.coffee')
+http = require('http')
+
+expect = require('chai').expect
+
+process.env.EXPRESS_PORT = 8080
+
+describe 'hello-world', ->
+  beforeEach ->
+    @room = helper.createRoom(httpd: true)
+
+  context 'GET /hello/world', ->
+    beforeEach (done) ->
+      http.get 'http://localhost:8080/hello/world', (@response) => done()
+      .on 'error', done
+
+    it 'responds with status 200', ->
+      expect(@response.statusCode).to.equal 200

--- a/test/httpd-world_test.coffee
+++ b/test/httpd-world_test.coffee
@@ -8,7 +8,7 @@ process.env.EXPRESS_PORT = 8080
 
 describe 'hello-world', ->
   beforeEach ->
-    @room = helper.createRoom(httpd: true)
+    @room = helper.createRoom()
 
   context 'GET /hello/world', ->
     beforeEach (done) ->

--- a/test/scripts/httpd-world.coffee
+++ b/test/scripts/httpd-world.coffee
@@ -1,0 +1,3 @@
+module.exports = (robot) ->
+  robot.router.get "/hello/world", (req, res) ->
+    res.status(200).send("Hello World!")


### PR DESCRIPTION
The use case for this feature is so scripts that utilize Hubot's router (HTTPD) features can be tested. I (and many others) have several Hubot scripts that respond to GET and POST requests via the Hubot's Web Hook API. I use these to configure SSH keys stored in Redis (robot.brain) and for sending notifications from build/deploy scripts so Hubot can announce to users when a build is complete.

Fixes issue #3