### PR TITLE
Add support for the sendPrivate function.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,9 +2,15 @@ Fs    = require('fs')
 Path  = require('path')
 Hubot = require('hubot')
 
+class MockResponse extends Hubot.Response
+  sendPrivate: (strings...) ->
+    @robot.adapter.sendPrivate @envelope, strings...
+
 class MockRobot extends Hubot.Robot
   constructor: (httpd=true) ->
     super null, null, httpd, 'hubot'
+
+    @Response = MockResponse
 
   loadAdapter: ->
     @adapter = new Room(@)
@@ -12,6 +18,8 @@ class MockRobot extends Hubot.Robot
 class Room extends Hubot.Adapter
   constructor: (@robot) ->
     @messages = []
+
+    @privateMessages = {}
 
     @user =
       say: (userName, message) =>
@@ -31,6 +39,11 @@ class Room extends Hubot.Adapter
 
   send: (envelope, strings...) ->
     @messages.push ['hubot', str] for str in strings
+
+  sendPrivate: (envelope, strings...) ->
+    if envelope.user.name not of @privateMessages
+      @privateMessages[envelope.user.name] = []
+    @privateMessages[envelope.user.name].push ['hubot', str] for str in strings
 
 class Helper
   constructor: (scriptsPath) ->

--- a/test/httpd-world_test.coffee
+++ b/test/httpd-world_test.coffee
@@ -6,7 +6,7 @@ expect = require('chai').expect
 
 process.env.EXPRESS_PORT = 8080
 
-describe 'hello-world', ->
+describe 'httpd-world', ->
   beforeEach ->
     @room = helper.createRoom()
 

--- a/test/private-message_test.coffee
+++ b/test/private-message_test.coffee
@@ -1,0 +1,25 @@
+Helper = require('../src/index')
+helper = new Helper('./scripts/private-message.coffee')
+
+expect = require('chai').expect
+
+describe 'private-message', ->
+
+  beforeEach ->
+    @room = helper.createRoom(httpd: false)
+
+  context 'user asks hubot for a secret', ->
+    beforeEach ->
+      @room.user.say 'alice', '@hubot tell me a secret'
+
+    it 'should not post to the public channel', ->
+      expect(@room.messages).to.eql [
+        ['alice', '@hubot tell me a secret']
+      ]
+
+    it 'should private message user', ->
+      expect(@room.privateMessages).to.eql {
+        'alice': [
+          ['hubot', 'whisper whisper whisper']
+        ]
+      }

--- a/test/scripts/private-message.coffee
+++ b/test/scripts/private-message.coffee
@@ -1,0 +1,5 @@
+# Description:
+#   Test script
+module.exports = (robot) ->
+  robot.respond /tell me a secret$/i, (msg) ->
+    msg.sendPrivate 'whisper whisper whisper'


### PR DESCRIPTION
This is stored in a similar way to the messages, but private messages to individual users are nested in an associative array.  Here's a quick example:

```coffee
expect(room.messages).to.eql [
  ['alice', 'hubot private pug me']
]

expect(room.privateMessages).to.eql {
  'alice': [
    ['hubot', 'http://25.media.tumblr.com/tumblr_mblaw5jZ0v1qbbpjfo1_500.jpg']
  ]
}
```