### PR TITLE
Suppress "possible EventEmitter memory leak detected" warnings.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,6 +2,8 @@ Fs    = require('fs')
 Path  = require('path')
 Hubot = require('hubot')
 
+process.setMaxListeners(0)
+
 class MockResponse extends Hubot.Response
   sendPrivate: (strings...) ->
     @robot.adapter.sendPrivate @envelope, strings...


### PR DESCRIPTION
I ran across this as I began breaking out tests into multiple files and running them in the following way:

```bash
node_modules/.bin/mocha --compilers coffee:coffee-script/register test
```

This appears to be a well documented problem that appears in many testing libraries ([here's a thread from the node-gently testing suite discussing the same issue](https://github.com/felixge/node-gently/issues/17)).  I believe the core of the problem has to do with how the hubot module sets up and tears down Emitters/Listeners.  It doesn't seem to affect the outcome of the tests, it's just a warning to the user.

If you've managed to avoid this error by running the tests some other way, please let me know.  I'm pretty inexperienced with testing with mocha, so there's a good chance I'm running things wrong.

**Before**:
![](http://s.amussey.com/SEYc.png)

**After**:
![](http://s.amussey.com/OrhL.png)