### PR TITLE
Add the ability for tests to mock hubot's response class.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -48,11 +48,16 @@ class Room extends Hubot.Adapter
     @privateMessages[envelope.user.name].push ['hubot', str] for str in strings
 
 class Helper
+  @Response = MockResponse
+
   constructor: (scriptsPath) ->
     @scriptsPath = Path.resolve(Path.dirname(module.parent.filename), scriptsPath)
 
   createRoom: (options={}) ->
     robot = new MockRobot(options.httpd)
+
+    if 'response' of options
+      robot.Response = options.response
 
     if Fs.statSync(@scriptsPath).isDirectory()
       for file in Fs.readdirSync(@scriptsPath).sort()

--- a/test/mock-response_test.coffee
+++ b/test/mock-response_test.coffee
@@ -1,0 +1,26 @@
+Helper = require('../src/index')
+helper = new Helper('./scripts/mock-response.coffee')
+
+expect = require('chai').expect
+
+class NewMockResponse extends Helper.Response
+  random: (items) ->
+    3
+
+describe 'mock-response', ->
+
+  beforeEach ->
+    @room = helper.createRoom(response: NewMockResponse)
+
+  context 'user says "give me a random" number to hubot', ->
+    beforeEach ->
+      @room.user.say 'alice', '@hubot give me a random number'
+      @room.user.say 'bob',   '@hubot give me a random number'
+
+    it 'should reply to user with a random number', ->
+      expect(@room.messages).to.eql [
+        ['alice', '@hubot give me a random number']
+        ['hubot', '@alice 3']
+        ['bob',   '@hubot give me a random number']
+        ['hubot', '@bob 3']
+      ]

--- a/test/scripts/mock-response.coffee
+++ b/test/scripts/mock-response.coffee
@@ -1,0 +1,6 @@
+# Description:
+#   Test script
+module.exports = (robot) ->
+  robot.respond /give me a random number$/i, (msg) ->
+    randomNumber = msg.random [1, 2, 3, 4, 5]
+    msg.reply randomNumber


### PR DESCRIPTION
This allows for predictable testing of scripts that use calls such as `msg.random`.