### PR TITLE
Set the max Hubot version to 2.14.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "hubot"
   ],
   "dependencies": {
-    "hubot": ">= 2.6.0 < 3.0.0"
+    "hubot": ">= 2.6.0 < 2.14.0"
   },
   "devDependencies": {
     "chai": "latest",


### PR DESCRIPTION
In version 2.14.0, Hubot started using the `async` module to respond to received messages (in `Hubot.Robot`).  Tests can technically still be run with the current code, but all tests will need to be modified to include a short timeout in the `beforeEach` function.

```coffeescript
    beforeEach (done) ->
      room.user.say 'alice', 'hubot pug me'
      setTimeout done, 50
```

I've filed this as an [issue](https://github.com/mtsmfm/hubot-test-helper/issues/10), but this PR could potentially serve as a temporary solution.