### PR TITLE
add robotEvent method available from tests

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -47,6 +47,10 @@ class Room extends Hubot.Adapter
       @privateMessages[envelope.user.name] = []
     @privateMessages[envelope.user.name].push ['hubot', str] for str in strings
 
+  robotEvent: () ->
+    @robot.emit.apply(@robot, arguments)
+
+
 class Helper
   @Response = MockResponse
 

--- a/test/events.coffee
+++ b/test/events.coffee
@@ -1,0 +1,20 @@
+Helper = require('../src/index')
+helper = new Helper('./scripts/events.coffee')
+
+co     = require('co')
+expect = require('chai').expect
+
+describe 'events', ->
+
+  beforeEach ->
+    @room = helper.createRoom(httpd: false)
+
+  context 'should post on an event', ->
+    beforeEach ->
+      @room.robotEvent 'some-event', 'event', 'data'
+
+    it 'should reply to user', ->
+      expect(@room.messages).to.eql [
+        ['hubot', 'got event with event data']
+      ]
+

--- a/test/scripts/events.coffee
+++ b/test/scripts/events.coffee
@@ -1,0 +1,6 @@
+# Description:
+#   Test script
+module.exports = (robot) ->
+  robot.on 'some-event', (some, data) ->
+    robot.messageRoom 'room1', "got event with #{some} #{data}"
+


### PR DESCRIPTION
This change allows for a test to emit custom events on the robot in use.
It uses a different method name than `emit` in order to not mess with basic EventEmitter methods.