### PR TITLE
Fix description about turnning off httpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default Hubot enables a built in HTTP server. The server continues between
 tests and so requires it to be shutdown during teardown using `room.destroy()`.
 
 This feature can be turned off in tests that don't need it by passing using
-`helper.createRoom(http: false)`.
+`helper.createRoom(httpd: false)`.
 
 See [the tests](test/httpd-world_test.coffee) for an example of testing the
 HTTP server.


### PR DESCRIPTION
I intended to use `helper.createRoom(http: false)` to turn off  built in HTTP server. But I found the http property doesn't work. After reading the source code [index.coffee#L76](https://github.com/mtsmfm/hubot-test-helper/blob/master/src/index.coffee#L76), I found `http` should be `httpd`.