### PR TITLE
JS & coffeescript-compatible npm packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/lib

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Fumiaki Matsushima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "hubot-test-helper",
   "description": "Helper for testing hubot script",
-  "main": "./src/index",
+  "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register test",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "prepublish": "coffee --compile --output lib/ src/"
   },
   "keywords": [
     "hubot"
@@ -16,6 +17,7 @@
     "chai": "latest",
     "co": "latest",
     "coffee-script": "latest",
+    "lodash": "^3.10.1",
     "mocha": "latest",
     "semantic-release": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "chai": "latest",
     "co": "latest",
     "coffee-script": "latest",
-    "lodash": "^3.10.1",
     "mocha": "latest",
     "semantic-release": "^4.3.5"
   },


### PR DESCRIPTION
This pull request addresses the issue #21. It will:
- compile `src/*.coffee` into `lib/*.js` during `npm prepublish`
- specifies `lib/index.js` as main for the npm package
- ignore the compiled `lib` from github. 

Please inspect, and this shall only require your:
- merging the pull request, and
- publishing it to npm
