### PR TITLE
add JS test to ensure JS passes Travis too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.DS_Store

--- a/test/hello-world_test.js
+++ b/test/hello-world_test.js
@@ -1,0 +1,34 @@
+var Helper, co, expect, helper;
+
+Helper = require('../src/index');
+
+helper = new Helper('./scripts/hello-world.coffee');
+
+co = require('co');
+
+expect = require('chai').expect;
+
+describe('hello-world-js', function() {
+  beforeEach(function() {
+    return this.room = helper.createRoom({
+      httpd: false
+    });
+  });
+  return context('user says hi to hubot', function() {
+    beforeEach(function() {
+      return co((function(_this) {
+        return function*() {
+          (yield _this.room.user.say('alice', '@hubot hi'));
+          return (yield _this.room.user.say('bob', '@hubot hi'));
+        };
+      })(this));
+    });
+    return it('should reply to user', function() {
+      return expect(this.room.messages).to.eql([
+        ['alice', '@hubot hi'],
+        ['hubot', '@alice hi'],
+        ['bob', '@hubot hi'],
+        ['hubot', '@bob hi']]);
+    });
+  });
+});

--- a/test/scripts/hello-world.js
+++ b/test/scripts/hello-world.js
@@ -1,0 +1,8 @@
+// Description:
+//   Test script
+module.exports = function(robot) {
+	// ping to test connection
+	robot.respond(/hi$/i, function(msg){
+		msg.reply('hi')
+	})
+}


### PR DESCRIPTION
Just so #23 doesn't happen in the future. A JS test is added so Travis will check it too.
The same command `npm test` runs all the `coffee` and `js` tests, so no modifications required.
As usual please merge n publish?