### PR TITLE
feat: Update hubot dependency to allow for hubot 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hubot"
   ],
   "dependencies": {
-    "hubot": ">= 2.6.0 < 3"
+    "hubot": ">=2.6.0 <10 || 0.0.0-development"
   },
   "devDependencies": {
     "chai": "latest",


### PR DESCRIPTION
There has been a fair amount of work upstream in hubot recently. We are
really close to a 3.0 release (there is actually a `next` release of
it), and I wanted to make sure this library supported it since it is
recommended in the hubot documentation.

See https://github.com/hubotio/hubot/issues/1057 for more info on this

Also cc https://github.com/hubotio/hubot-for-hubot/pull/16 where I ran into this peer dependency