### PR TITLE
fix(npm package): Add back src directory to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-/src
 /dummy


### PR DESCRIPTION
Now that coffeescript is not generating any code, the npm package actually has no code, the src/ directory is not included in the npm package.