### PR TITLE
feat: add ability to test robot.messageRoom(...)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,20 @@ class MockRobot extends Hubot.Robot {
     if (httpd == null) { httpd = true; }
     super(null, null, httpd, 'hubot');
 
+    this.messagesTo = {};
+
     this.Response = MockResponse;
+  }
+
+  messageRoom(roomName, str) {
+    if (roomName == this.adapter.name) {
+      this.adapter.messages.push(['hubot', str]);
+    } else {
+      if (!(roomName in this.messagesTo)) {
+        this.messagesTo[roomName] = [];
+      }
+      this.messagesTo[roomName].push(['hubot', str]);
+    }
   }
 
   loadAdapter() {

--- a/test/message-room_test.js
+++ b/test/message-room_test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Helper = require('../src/index');
+const helper = new Helper('./scripts/message-room.js');
+
+const co     = require('co');
+const expect = require('chai').expect;
+
+describe('message-room', function() {
+  beforeEach(function() {
+    this.room = helper.createRoom({name: 'room', httpd: false});
+  });
+
+  context('user asks hubot to announce something', function() {
+    beforeEach(function() {
+      return co(function*() {
+        yield this.room.user.say('alice', '@hubot announce otherRoom: I love hubot!');
+      }.bind(this));
+    });
+
+    it('should not post to this channel', function() {
+      expect(this.room.messages).to.eql([
+        ['alice', '@hubot announce otherRoom: I love hubot!']
+      ]);
+    });
+
+    it('should post to the other channel', function() {
+      expect(this.room.robot.messagesTo['otherRoom']).to.eql([
+        ['hubot', '@alice says: I love hubot!']
+      ]);
+    });
+  });
+});

--- a/test/scripts/message-room.js
+++ b/test/scripts/message-room.js
@@ -1,0 +1,6 @@
+// Description:
+//   Test script
+module.exports = robot =>
+  robot.respond(/announce otherRoom: (.+)$/i, msg => {
+    robot.messageRoom('otherRoom', '@' + msg.envelope.user.name + ' says: ' + msg.match[1]);
+  })


### PR DESCRIPTION
- messages sent via `robot.messageRoom(...)` to the current room (i.e. named the same as the mocked room) are piped to the room's `messages` property and can be tested via `room.messages` like normal (as in the existing `events` test).

- messages sent via `robot.messageRoomt(...)` to a room with a different name are stored in a new `robot.messagesTo` hash similar to the existing `room.privateMessages` hash and can be accessed in assertions as shown in the updated `README`:

> Given the following script:
> ```javascript
> module.exports = robot =>
>  robot.respond(/announce otherRoom: (.+)$/i, msg => {
>    robot.messageRoom('otherRoom', "@#{msg.envelope.user.name} said: #{msg.msg.match[1]}");
>  })
> ```
>
> you could test the messages sent to other rooms like this:
> ```javascript
> const Helper = require('../src/index');
> const helper = new Helper('../scripts/message-room.js');
> 
> const expect = require('chai').expect;
> 
> describe('message-room', function() {
>   beforeEach(function() {
>     this.room = helper.createRoom({name: 'room', httpd: false});
>   });
> 
>   context('user asks hubot to announce something', function() {
>     beforeEach(function() {
>       return co(function*() {
>         yield this.room.user.say('alice', '@hubot announce otherRoom: I love hubot!');
>       }.bind(this));
>     });
> 
>     it('should not post to this channel', function() {
>       expect(this.room.messages).to.eql([
>         ['alice', '@hubot announce otherRoom: I love hubot!']
>       ]);
>     });
> 
>     it('should post to the other channel', function() {
>       expect(this.room.robot.messagesTo['otherRoom']).to.eql([
>         ['hubot', '@alice says: I love hubot!']
>       ]);
>     });
>   });
> });
> ```