### PR TITLE
chore: add an autotest npm target

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "./src/index.js",
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register test",
+    "autotest": "mocha --compilers coffee:coffee-script/register test -w",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "keywords": [


### PR DESCRIPTION
- the `autotest` npm target allows rapid feedback by running mocha with the `watch` flag; now instead of running 
```
npm test
```
you now have an alternative to run
```
npm run autotest
```
and you will see the tests run every time you save a file.