### PR TITLE
Fixes to make work with hubot 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot"
   ],
   "dependencies": {
-    "hubot": ">=5.0.0 <6.0.0 || 0.0.0-development"
+    "hubot": ">=5.0.0 <7.0.0 || 0.0.0-development"
   },
   "devDependencies": {
     "chai": "latest",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot"
   ],
   "dependencies": {
-    "hubot": ">=3.0.0 <10 || 0.0.0-development"
+    "hubot": ">=5.0.0 <6.0.0 || 0.0.0-development"
   },
   "devDependencies": {
     "chai": "latest",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ class MockResponse extends Hubot.Response {
 class MockRobot extends Hubot.Robot {
   constructor(httpd) {
     if (httpd == null) { httpd = true; }
-    super(null, null, httpd, 'hubot');
+    super(null, httpd, 'hubot', 'hubot');
 
     this.messagesTo = {};
 
@@ -140,6 +140,7 @@ class Helper {
   createRoom(options) {
     if (options == null) { options = {}; }
     const robot = new MockRobot(options.httpd);
+    robot.loadAdapter();
 
     if ('response' in options) {
       robot.Response = options.response;


### PR DESCRIPTION
These updates helped me get hubot-test-helper working with the current 5.0.7 version of hubot.